### PR TITLE
refactor(lib/decoder): 优化变量名

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -7,23 +7,23 @@ const RpcCommandType = require('./protocol/enum/rpc_type');
 const packetLengthFns = {
   1(buf, bufLength) {
     const type = buf[1];
-    const headerLength = type === RpcCommandType.RESPONSE ? 20 : 22;
-    if (bufLength < headerLength) {
+    const baseLength = type === RpcCommandType.RESPONSE ? 20 : 22;
+    if (bufLength < baseLength) {
       return 0;
     }
     return type === RpcCommandType.RESPONSE ?
-      headerLength + buf.readInt16BE(12) + buf.readInt16BE(14) + buf.readInt32BE(16) :
-      headerLength + buf.readInt16BE(14) + buf.readInt16BE(16) + buf.readInt32BE(18);
+      baseLength + buf.readInt16BE(12) + buf.readInt16BE(14) + buf.readInt32BE(16) :
+      baseLength + buf.readInt16BE(14) + buf.readInt16BE(16) + buf.readInt32BE(18);
   },
   2(buf, bufLength) {
     const type = buf[2];
-    const headerLength = type === RpcCommandType.RESPONSE ? 22 : 24;
-    if (bufLength < headerLength) {
+    const baseLength = type === RpcCommandType.RESPONSE ? 22 : 24;
+    if (bufLength < baseLength) {
       return 0;
     }
     let len = type === RpcCommandType.RESPONSE ?
-      headerLength + buf.readInt16BE(14) + buf.readInt16BE(16) + buf.readInt32BE(18) :
-      headerLength + buf.readInt16BE(16) + buf.readInt16BE(18) + buf.readInt32BE(20);
+      baseLength + buf.readInt16BE(14) + buf.readInt16BE(16) + buf.readInt32BE(18) :
+      baseLength + buf.readInt16BE(16) + buf.readInt16BE(18) + buf.readInt32BE(20);
     // 如果 crc 校验开启，还需要加 4 bytes
     if (buf[11] === 0x01) {
       len += 4;


### PR DESCRIPTION
```js
const headerLength = type === RpcCommandType.RESPONSE ? 20 : 22;
```
第一眼看去，以为是header的长度。。。。